### PR TITLE
Query by class as a string

### DIFF
--- a/lib/crier/notification.rb
+++ b/lib/crier/notification.rb
@@ -12,7 +12,7 @@ module Crier
 
     scope :by,       lambda {|user| where(:crier_id => user) }
     scope :heard_by, lambda {|user| joins("LEFT OUTER JOIN #{Listening.table_name} ON #{Listening.table_name}.notification_id = #{table_name}.id").where("#{Listening.table_name}.user_id = #{user.id} OR NOT private")}
-    scope :about,    lambda {|subject| where(:subject_id => subject.id, :subject_type => subject.class) }
+    scope :about,    lambda {|subject| where(:subject_id => subject.id, :subject_type => subject.class.name) }
     scope :in_scope, lambda {|scope| where(:scope => scope) }
 
     # Shortcut for creating a private audience for this notification


### PR DESCRIPTION
Rails 5 deprecation, per https://github.com/rails/rails/pull/17916