### PR TITLE
Add Ruby 3 + Rails 7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5']
-        appraisal-version: ['rails-4', 'rails-5', 'rails-6']
+        ruby-version: ['2.5', '3.0']
+        gemfile: ['rails_5', 'rails_6', 'rails_7']
+        exclude:
+          - ruby-version: '3.0'
+            gemfile: 'rails_5'
+          - ruby-version: '2.5'
+            gemfile: 'rails_7'
+
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
+      BUNDLE_PATH_RELATIVE_TO_CWD: true
+      RAILS_ENV: test
+
     steps:
     - uses: actions/checkout@v2
 
@@ -21,14 +32,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler: 1
+        bundler: default
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-    - name: Setup appraisal
-      run: |
-        bundle exec appraisal install
-
     - name: Run all tests
-      env:
-        RAILS_ENV: test
-      run: bundle exec appraisal ${{ matrix.appraisal-version }} rake spec
+      run: bundle exec rake spec

--- a/Appraisals
+++ b/Appraisals
@@ -1,8 +1,3 @@
-appraise "rails-4" do
-  gem "rails", "~> 4", "< 5"
-  gem "sqlite3", "~> 1.3.6"
-end
-
 appraise "rails-5" do
   gem "rails", "~> 5", "< 6"
   gem "sqlite3", "~> 1.3.6"
@@ -10,4 +5,10 @@ end
 
 appraise "rails-6" do
   gem "rails", "~> 6", "< 7"
+  gem "sqlite3"
+end
+
+appraise "rails-7" do
+  gem "rails", "~> 7", "< 8"
+  gem "sqlite3"
 end

--- a/crier.gemspec
+++ b/crier.gemspec
@@ -15,9 +15,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", [">= 4", "< 7"]
+  s.add_dependency "rails", [">= 5", "< 8"]
 
-  s.add_development_dependency('bundler', '~> 1')
+  s.add_development_dependency('bundler')
   s.add_development_dependency('sqlite3', '~> 1.4')
   s.add_development_dependency('appraisal')
   s.add_development_dependency('rspec-rails', '~> 4')

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -3,5 +3,6 @@
 source "http://rubygems.org"
 
 gem "rails", "~> 6", "< 7"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -2,7 +2,7 @@
 
 source "http://rubygems.org"
 
-gem "rails", "~> 4", "< 5"
-gem "sqlite3", "~> 1.3.6"
+gem "rails", "~> 7", "< 8"
+gem "sqlite3"
 
 gemspec path: "../"


### PR DESCRIPTION
This initially was just meant to add Ruby 3 and Rails 7 but I discovered that Rails 5 was [broken by this commit](https://github.com/culturecode/crier/commit/80613acd24f7d3e65525b084ee8dee630ba1ac64) so figured we should just drop it.

I also needed to basically stop using the Appraisal gem in CI since [it can't handle conflicting versions of Ruby](https://github.com/thoughtbot/appraisal/issues/182).  Ruby 2.5 isn't compatible with Rails 7 so `bundle exec appraisal install` wasn't working.